### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/RuneWork2/keywords.txt
+++ b/RuneWork2/keywords.txt
@@ -9,7 +9,7 @@ nbScheduleTasks	KEYWORD2
 getTasksBufferLength	KEYWORD2
 getScheduleBufferLength	KEYWORD2
 initRuneWork	KEYWORD2
-setRuneWorkPeriod KEYWORD2
+setRuneWorkPeriod	KEYWORD2
 initSound	KEYWORD2
 getSongFlag	KEYWORD2
 startSong	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords